### PR TITLE
Update SparseSet.cs

### DIFF
--- a/ecs/SparseSet.cs
+++ b/ecs/SparseSet.cs
@@ -79,7 +79,7 @@ namespace SimpleECS
             }
         }
 
-        public uint Index(uint value) => sparse[value];
+        public uint Index(uint value) => dense[value];
 
         public bool Contains(uint value)
         {


### PR DESCRIPTION
When deleting entities I saw that all entities after the specific entity I wanted to delete were deleted. 

Turns out it is the Index method, so I changed it to return the index of the 'object' in the dense array. 