### PR TITLE
Patch 1

### DIFF
--- a/ecs/ComponentStore.cs
+++ b/ecs/ComponentStore.cs
@@ -33,11 +33,11 @@ namespace SimpleECS
         public void Add(Entity entity, T value)
         {
             Set.Add(entity.Id);
-            instances[Set.Index(entity.Id)] = value;
+            instances[entity.Id] = value;
             OnAdd?.Invoke(entity.Id);
         }
 
-        public ref T Get(uint entityId) => ref instances[Set.Index(entityId)];
+        public ref T Get(uint entityId) => ref instances[entityId];
 
         public bool Contains(uint entityId) => Set.Contains(entityId);
 

--- a/ecs/SparseSet.cs
+++ b/ecs/SparseSet.cs
@@ -79,8 +79,6 @@ namespace SimpleECS
             }
         }
 
-        public uint Index(uint value) => dense[value];
-
         public bool Contains(uint value)
         {
             if (value >= max || value < 0)


### PR DESCRIPTION
The Index method has been removed.

To retrieve the actual value in the dense array, dense[sparse[value]] is used. Since we know that this value will exist in the sparse set, we can simplify the method to return value. This is due to the fact that we are using "Get" methods.

Unless the code is misused, the value will exist in the array, given the pattern of the library.